### PR TITLE
refact : 로그인 코드 리팩토링

### DIFF
--- a/src/main/java/tback/kicketingback/auth/dto/TokenResponse.java
+++ b/src/main/java/tback/kicketingback/auth/dto/TokenResponse.java
@@ -1,8 +1,24 @@
 package tback.kicketingback.auth.dto;
 
-public record TokenResponse(String accessToken, String refreshToken){
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public record TokenResponse(String accessToken, String refreshToken) {
 
 	public static TokenResponse of(String accessToken, String refreshToken) {
 		return new TokenResponse(accessToken, refreshToken);
+	}
+
+	public void setAccessToken(HttpServletResponse response, int expirationTime) {
+		ResponseCookie accessTokenCookie = ResponseCookie.from(HttpHeaders.AUTHORIZATION, accessToken)
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.maxAge(expirationTime)
+			.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
 	}
 }

--- a/src/main/java/tback/kicketingback/auth/oauth/controller/OauthSignInController.java
+++ b/src/main/java/tback/kicketingback/auth/oauth/controller/OauthSignInController.java
@@ -2,8 +2,6 @@ package tback.kicketingback.auth.oauth.controller;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,14 +58,7 @@ public class OauthSignInController {
 
 		TokenResponse tokenResponse = oauthSignInService.signInUser(oauthUser.email());
 
-		ResponseCookie accessTokenCookie = ResponseCookie.from(HttpHeaders.AUTHORIZATION, tokenResponse.accessToken())
-			.httpOnly(true)
-			.secure(true)
-			.path("/")
-			.maxAge(EXPIRATION_TIME)
-			.build();
-
-		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+		tokenResponse.setAccessToken(response, EXPIRATION_TIME);
 		return ResponseEntity.ok().body(tokenResponse.refreshToken());
 	}
 }

--- a/src/main/java/tback/kicketingback/user/signin/controller/SignInController.java
+++ b/src/main/java/tback/kicketingback/user/signin/controller/SignInController.java
@@ -1,8 +1,6 @@
 package tback.kicketingback.user.signin.controller;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,17 +25,11 @@ public class SignInController {
 	private final SignInService signInService;
 
 	@PostMapping("/sign-in")
-	public ResponseEntity<String> signIn(@RequestBody @Valid SignInRequest signInRequest, HttpServletResponse response) {
+	public ResponseEntity<String> signIn(@RequestBody @Valid SignInRequest signInRequest,
+		HttpServletResponse response) {
 		TokenResponse tokenResponse = signInService.signInUser(signInRequest);
 
-		ResponseCookie accessTokenCookie = ResponseCookie.from(HttpHeaders.AUTHORIZATION, tokenResponse.accessToken())
-			.httpOnly(true)
-			.secure(true)
-			.path("/")
-			.maxAge(EXPIRATION_TIME)
-			.build();
-
-		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+		tokenResponse.setAccessToken(response, EXPIRATION_TIME);
 		return ResponseEntity.ok().body(tokenResponse.refreshToken());
 	}
 }


### PR DESCRIPTION
- 오어스 로그인, 기본 로그인: 컨트롤러에서 액서스 토큰을 헤더에 세팅함 -> 중복 코드 문제가 발생 -> 중복 코드를 TokenResponse로 메서드 형태로 이전함

## 📄 Summary
> #26 로그인에서 액서스 토큰을 헤더에 넣어주는 로직이 중복입니다.
따라서 공통 로직을 메서드로 추출해 TokenResponse으로 이전했어요.

## 🙋🏻 More
> 중복 코드 out!🔥🔥🔥
