### PR TITLE
fix : 오어스 회원가입 이메일 전송 버그 수정

### DIFF
--- a/src/main/java/tback/kicketingback/auth/oauth/service/OauthSignupService.java
+++ b/src/main/java/tback/kicketingback/auth/oauth/service/OauthSignupService.java
@@ -1,7 +1,5 @@
 package tback.kicketingback.auth.oauth.service;
 
-import static tback.kicketingback.global.encode.PasswordEncoderSHA256.*;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +22,6 @@ public class OauthSignupService implements SignUpService {
 	public void signUp(SignUpRequest signUpRequest) {
 		User user = User.of(signUpRequest.email(), signUpRequest.password(), signUpRequest.name());
 		userRepository.save(user);
-		smtpService.sendRandomPassword(user.getEmail(), user.getPassword());
+		smtpService.sendRandomPassword(user.getEmail(), signUpRequest.password());
 	}
 }


### PR DESCRIPTION
- 이메일 전송시 암호화된 임시 비밀번호가 전송됨.
- 오어스 회원가입시 전송해줄 이메일에는 SignUpRequest.password을 첨부한다.

## 📄 Summary
> #28 오어스 회원가입시 임시 비밀번호를 안내하는 이메일에는 암호화되기 전의 평문 비밀번호를 첨부하도록 변경했어요.

## 🙋🏻 More
> 생각하지 못한 버그네요!! 빨리 발견해서 다행입니다. 😂😂😂
그래도 코드 구조가 좋아 버그를 발견했을때 코드를 수정하기 쉬운것 같아요 ㅎㅎ