### PR TITLE
feat : 로그아웃 기능

### DIFF
--- a/src/main/java/tback/kicketingback/auth/dto/TokenResponse.java
+++ b/src/main/java/tback/kicketingback/auth/dto/TokenResponse.java
@@ -11,6 +11,17 @@ public record TokenResponse(String accessToken, String refreshToken) {
 		return new TokenResponse(accessToken, refreshToken);
 	}
 
+	public static void expireAccessToken(HttpServletResponse response) {
+		ResponseCookie accessTokenCookie = ResponseCookie.from(HttpHeaders.AUTHORIZATION, "")
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.maxAge(0)
+			.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+	}
+
 	public void setAccessToken(HttpServletResponse response, int expirationTime) {
 		ResponseCookie accessTokenCookie = ResponseCookie.from(HttpHeaders.AUTHORIZATION, accessToken)
 			.httpOnly(true)

--- a/src/main/java/tback/kicketingback/user/signout/controller/SignOutController.java
+++ b/src/main/java/tback/kicketingback/user/signout/controller/SignOutController.java
@@ -1,0 +1,29 @@
+package tback.kicketingback.user.signout.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import tback.kicketingback.auth.dto.TokenResponse;
+import tback.kicketingback.auth.jwt.JwtLogin;
+import tback.kicketingback.user.domain.User;
+import tback.kicketingback.user.signout.service.SignOutService;
+
+@RestController
+@RequestMapping("/api/user/sign-out")
+@RequiredArgsConstructor
+public class SignOutController {
+
+	private final SignOutService signOutService;
+
+	@PostMapping
+	public ResponseEntity<Void> signOut(@JwtLogin User user, HttpServletResponse response) {
+		signOutService.signOutUser(user);
+		TokenResponse.expireAccessToken(response);
+
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/tback/kicketingback/user/signout/service/SignOutService.java
+++ b/src/main/java/tback/kicketingback/user/signout/service/SignOutService.java
@@ -1,0 +1,21 @@
+package tback.kicketingback.user.signout.service;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import tback.kicketingback.global.repository.RedisRepository;
+import tback.kicketingback.user.domain.User;
+
+@Service
+public class SignOutService {
+
+	private final RedisRepository refreshRedisRepository;
+
+	public SignOutService(@Qualifier("refreshRedisRepository") RedisRepository refreshRedisRepository) {
+		this.refreshRedisRepository = refreshRedisRepository;
+	}
+
+	public void signOutUser(User user) {
+		refreshRedisRepository.deleteValues(user.getEmail());
+	}
+}


### PR DESCRIPTION
## 📄 Summary
> #44 로그아웃 기능

- 리프레시 토큰을 관리하는 레디스에서 해당 유저의 리프레시 토큰을 삭제
- 응답에 maxAge가 0인 액서스 토큰을 설정하는 방식으로 액서스 토큰을 만료시킨다.

## 🙋🏻 More
> 자세한 정보는 postman을 참고해주세용 😎👍
