### PR TITLE
Feature/#66 좌석정보 제공

### DIFF
--- a/src/main/java/tback/kicketingback/global/exception/AbstractExceptionHandler.java
+++ b/src/main/java/tback/kicketingback/global/exception/AbstractExceptionHandler.java
@@ -18,6 +18,11 @@ public abstract class AbstractExceptionHandler {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
 	}
 
+	protected final <T> ResponseEntity<T> getBadRequestResponseEntity(final Exception exception, final T info) {
+		log.info("{}: {} response send because of Bad Request: {}", this.getClass(), exception.getClass(), info);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(info);
+	}
+
 	protected final ResponseEntity<String> getForbiddenResponseEntity(final Exception exception, final String message) {
 		log.info("{}: {} response send because of Forbidden: {}", this.getClass(), exception.getClass(), message);
 		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(message);

--- a/src/main/java/tback/kicketingback/performance/controller/ReservationController.java
+++ b/src/main/java/tback/kicketingback/performance/controller/ReservationController.java
@@ -6,12 +6,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import tback.kicketingback.auth.jwt.JwtLogin;
 import tback.kicketingback.performance.dto.GetSeatInfoResponse;
+import tback.kicketingback.performance.dto.LockOnStageSeatsRequest;
 import tback.kicketingback.performance.service.ReservationService;
+import tback.kicketingback.user.domain.User;
 
 @RestController
 @RequestMapping("/api/reservation")
@@ -29,5 +35,14 @@ public class ReservationController {
 		GetSeatInfoResponse seatInfo = reservationService.getSeatInfo(performanceUUID, onStageId);
 
 		return ResponseEntity.ok(seatInfo);
+	}
+
+	@PostMapping
+	public ResponseEntity<Void> lockOnStageSeats(
+		@JwtLogin User user,
+		@RequestBody @Valid LockOnStageSeatsRequest lockOnStageSeatsRequest
+	) {
+		reservationService.lockSeats(lockOnStageSeatsRequest.seatIds(), user);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/controller/ReservationController.java
+++ b/src/main/java/tback/kicketingback/performance/controller/ReservationController.java
@@ -1,0 +1,33 @@
+package tback.kicketingback.performance.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import tback.kicketingback.performance.dto.GetSeatInfoResponse;
+import tback.kicketingback.performance.service.ReservationService;
+
+@RestController
+@RequestMapping("/api/reservation")
+@RequiredArgsConstructor
+@Validated
+public class ReservationController {
+
+	private final ReservationService reservationService;
+
+	@GetMapping("/{uuid}/{onStageId}")
+	public ResponseEntity<GetSeatInfoResponse> getSeatInfo(
+		@PathVariable("uuid") UUID performanceUUID,
+		@PathVariable("onStageId") Long onStageId
+	) {
+		GetSeatInfoResponse seatInfo = reservationService.getSeatInfo(performanceUUID, onStageId);
+
+		return ResponseEntity.ok(seatInfo);
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/controller/ReservationController.java
+++ b/src/main/java/tback/kicketingback/performance/controller/ReservationController.java
@@ -37,12 +37,13 @@ public class ReservationController {
 		return ResponseEntity.ok(seatInfo);
 	}
 
-	@PostMapping
+	@PostMapping("/{onStageId}")
 	public ResponseEntity<Void> lockOnStageSeats(
 		@JwtLogin User user,
+		@PathVariable("onStageId") Long onStageId,
 		@RequestBody @Valid LockOnStageSeatsRequest lockOnStageSeatsRequest
 	) {
-		reservationService.lockSeats(lockOnStageSeatsRequest.seatIds(), user);
+		reservationService.lockSeats(onStageId, lockOnStageSeatsRequest.seatIds(), user);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/domain/Reservation.java
+++ b/src/main/java/tback/kicketingback/performance/domain/Reservation.java
@@ -4,9 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.hibernate.annotations.Comment;
-import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.UuidGenerator;
-import org.springframework.data.annotation.CreatedDate;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -19,11 +17,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
+import lombok.Setter;
 import tback.kicketingback.performance.domain.type.DiscountType;
 import tback.kicketingback.user.domain.User;
 
 @Entity
 @Getter
+@Setter
 public class Reservation {
 
 	@Id

--- a/src/main/java/tback/kicketingback/performance/domain/Seat.java
+++ b/src/main/java/tback/kicketingback/performance/domain/Seat.java
@@ -12,9 +12,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
 import tback.kicketingback.performance.domain.type.Grade;
 
 @Entity
+@Getter
+@Setter
 public class Seat {
 
 	@Id

--- a/src/main/java/tback/kicketingback/performance/dto/AlreadySelectedSeatResponse.java
+++ b/src/main/java/tback/kicketingback/performance/dto/AlreadySelectedSeatResponse.java
@@ -1,0 +1,6 @@
+package tback.kicketingback.performance.dto;
+
+import java.util.List;
+
+public record AlreadySelectedSeatResponse(String errorMessage, List<SeatRowCol> seats) {
+}

--- a/src/main/java/tback/kicketingback/performance/dto/GetSeatInfoResponse.java
+++ b/src/main/java/tback/kicketingback/performance/dto/GetSeatInfoResponse.java
@@ -1,0 +1,9 @@
+package tback.kicketingback.performance.dto;
+
+import java.util.List;
+
+public record GetSeatInfoResponse(
+	List<SimpleSeatDTO> simpleSeatDTOS,
+	List<SeatGradeDTO> seatGradeDTOS
+) {
+}

--- a/src/main/java/tback/kicketingback/performance/dto/LockOnStageSeatsRequest.java
+++ b/src/main/java/tback/kicketingback/performance/dto/LockOnStageSeatsRequest.java
@@ -1,0 +1,29 @@
+package tback.kicketingback.performance.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import tback.kicketingback.performance.exception.exceptions.DuplicateSeatSelectionException;
+
+public record LockOnStageSeatsRequest(List<Long> seatIds) {
+
+	public LockOnStageSeatsRequest(
+		@NotNull(message = "좌석을 선택하지 않음")
+		@Size(min = 1, max = 10, message = "좌석 범위 넘음 [1 ~10개 가능]")
+		List<Long> seatIds
+	) {
+		validateSeatIds(seatIds);
+		this.seatIds = seatIds;
+	}
+
+	private void validateSeatIds(List<Long> seatIds) {
+		long count = seatIds.stream()
+			.distinct()
+			.count();
+
+		if (count != seatIds.size()) {
+			throw new DuplicateSeatSelectionException();
+		}
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/dto/SeatReservationDTO.java
+++ b/src/main/java/tback/kicketingback/performance/dto/SeatReservationDTO.java
@@ -1,0 +1,7 @@
+package tback.kicketingback.performance.dto;
+
+import tback.kicketingback.performance.domain.Reservation;
+import tback.kicketingback.performance.domain.Seat;
+
+public record SeatReservationDTO(Seat seat, Reservation reservation) {
+}

--- a/src/main/java/tback/kicketingback/performance/dto/SeatRowCol.java
+++ b/src/main/java/tback/kicketingback/performance/dto/SeatRowCol.java
@@ -1,0 +1,4 @@
+package tback.kicketingback.performance.dto;
+
+public record SeatRowCol(String col, int row) {
+}

--- a/src/main/java/tback/kicketingback/performance/dto/SeatRowCol.java
+++ b/src/main/java/tback/kicketingback/performance/dto/SeatRowCol.java
@@ -1,4 +1,4 @@
 package tback.kicketingback.performance.dto;
 
-public record SeatRowCol(String col, int row) {
+public record SeatRowCol(int row, String col) {
 }

--- a/src/main/java/tback/kicketingback/performance/dto/SimpleSeatDTO.java
+++ b/src/main/java/tback/kicketingback/performance/dto/SimpleSeatDTO.java
@@ -1,0 +1,11 @@
+package tback.kicketingback.performance.dto;
+
+import tback.kicketingback.performance.domain.type.Grade;
+
+public record SimpleSeatDTO(
+	Long id,
+	Grade grade,
+	String seatRow,
+	int seatCol
+) {
+}

--- a/src/main/java/tback/kicketingback/performance/exception/PerformanceExceptionHandler.java
+++ b/src/main/java/tback/kicketingback/performance/exception/PerformanceExceptionHandler.java
@@ -13,6 +13,8 @@ import tback.kicketingback.performance.exception.exceptions.InvalidGetPerformanc
 import tback.kicketingback.performance.exception.exceptions.InvalidGetPerformanceSizeException;
 import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceException;
 import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceUUIDException;
+import tback.kicketingback.performance.exception.exceptions.InvalidSeatIdException;
+import tback.kicketingback.performance.exception.exceptions.NoAvailableSeatsException;
 
 @RestControllerAdvice
 public class PerformanceExceptionHandler extends AbstractExceptionHandler {
@@ -52,6 +54,16 @@ public class PerformanceExceptionHandler extends AbstractExceptionHandler {
 
 	@ExceptionHandler(InvalidPerformanceException.class)
 	public ResponseEntity<String> invalidPerformanceException(InvalidPerformanceException exception) {
+		return getBadRequestResponseEntity(exception, exception.getMessage());
+	}
+
+	@ExceptionHandler(NoAvailableSeatsException.class)
+	public ResponseEntity<String> noAvailableSeatsException(NoAvailableSeatsException exception) {
+		return getBadRequestResponseEntity(exception, exception.getMessage());
+	}
+
+	@ExceptionHandler(InvalidSeatIdException.class)
+	public ResponseEntity<String> invalidSeatIdException(InvalidSeatIdException exception) {
 		return getBadRequestResponseEntity(exception, exception.getMessage());
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/exception/PerformanceExceptionHandler.java
+++ b/src/main/java/tback/kicketingback/performance/exception/PerformanceExceptionHandler.java
@@ -5,6 +5,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import tback.kicketingback.global.exception.AbstractExceptionHandler;
+import tback.kicketingback.performance.dto.AlreadySelectedSeatResponse;
+import tback.kicketingback.performance.exception.exceptions.AlreadySelectedSeatException;
+import tback.kicketingback.performance.exception.exceptions.DuplicateSeatSelectionException;
 import tback.kicketingback.performance.exception.exceptions.InvalidGenreException;
 import tback.kicketingback.performance.exception.exceptions.InvalidGetPerformanceDateUnitException;
 import tback.kicketingback.performance.exception.exceptions.InvalidGetPerformanceSizeException;
@@ -32,5 +35,17 @@ public class PerformanceExceptionHandler extends AbstractExceptionHandler {
 	@ExceptionHandler(InvalidPerformanceUUIDException.class)
 	public ResponseEntity<String> invalidPerformanceUUIDException(InvalidPerformanceUUIDException exception) {
 		return getBadRequestResponseEntity(exception, exception.getMessage());
+	}
+
+	@ExceptionHandler(DuplicateSeatSelectionException.class)
+	public ResponseEntity<String> duplicateSeatSelectionException(DuplicateSeatSelectionException exception) {
+		return getBadRequestResponseEntity(exception, exception.getMessage());
+	}
+
+	@ExceptionHandler(AlreadySelectedSeatException.class)
+	public ResponseEntity<AlreadySelectedSeatResponse> alreadySelectedSeatException(
+		AlreadySelectedSeatException exception) {
+		return getBadRequestResponseEntity(exception,
+			new AlreadySelectedSeatResponse(exception.getMessage(), exception.getSeatRowCol()));
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/exception/PerformanceExceptionHandler.java
+++ b/src/main/java/tback/kicketingback/performance/exception/PerformanceExceptionHandler.java
@@ -11,6 +11,7 @@ import tback.kicketingback.performance.exception.exceptions.DuplicateSeatSelecti
 import tback.kicketingback.performance.exception.exceptions.InvalidGenreException;
 import tback.kicketingback.performance.exception.exceptions.InvalidGetPerformanceDateUnitException;
 import tback.kicketingback.performance.exception.exceptions.InvalidGetPerformanceSizeException;
+import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceException;
 import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceUUIDException;
 
 @RestControllerAdvice
@@ -47,5 +48,10 @@ public class PerformanceExceptionHandler extends AbstractExceptionHandler {
 		AlreadySelectedSeatException exception) {
 		return getBadRequestResponseEntity(exception,
 			new AlreadySelectedSeatResponse(exception.getMessage(), exception.getSeatRowCol()));
+	}
+
+	@ExceptionHandler(InvalidPerformanceException.class)
+	public ResponseEntity<String> invalidPerformanceException(InvalidPerformanceException exception) {
+		return getBadRequestResponseEntity(exception, exception.getMessage());
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/exception/exceptions/AlreadySelectedSeatException.java
+++ b/src/main/java/tback/kicketingback/performance/exception/exceptions/AlreadySelectedSeatException.java
@@ -18,7 +18,7 @@ public class AlreadySelectedSeatException extends RuntimeException {
 
 	public static AlreadySelectedSeatException of(List<Seat> seats) {
 		List<SeatRowCol> rowCols = seats.stream()
-			.map(seat -> new SeatRowCol(seat.getSeatRow(), seat.getSeatCol()))
+			.map(seat -> new SeatRowCol(seat.getSeatCol(), seat.getSeatRow()))
 			.toList();
 		return new AlreadySelectedSeatException(rowCols);
 	}

--- a/src/main/java/tback/kicketingback/performance/exception/exceptions/AlreadySelectedSeatException.java
+++ b/src/main/java/tback/kicketingback/performance/exception/exceptions/AlreadySelectedSeatException.java
@@ -1,0 +1,25 @@
+package tback.kicketingback.performance.exception.exceptions;
+
+import java.util.List;
+
+import lombok.Getter;
+import tback.kicketingback.performance.domain.Seat;
+import tback.kicketingback.performance.dto.SeatRowCol;
+
+@Getter
+public class AlreadySelectedSeatException extends RuntimeException {
+
+	private final List<SeatRowCol> seatRowCol;
+
+	private AlreadySelectedSeatException(List<SeatRowCol> seatRowCol) {
+		super("이미 예약된 좌석");
+		this.seatRowCol = seatRowCol;
+	}
+
+	public static AlreadySelectedSeatException of(List<Seat> seats) {
+		List<SeatRowCol> rowCols = seats.stream()
+			.map(seat -> new SeatRowCol(seat.getSeatRow(), seat.getSeatCol()))
+			.toList();
+		return new AlreadySelectedSeatException(rowCols);
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/exception/exceptions/DuplicateSeatSelectionException.java
+++ b/src/main/java/tback/kicketingback/performance/exception/exceptions/DuplicateSeatSelectionException.java
@@ -1,0 +1,8 @@
+package tback.kicketingback.performance.exception.exceptions;
+
+public class DuplicateSeatSelectionException extends RuntimeException {
+
+	public DuplicateSeatSelectionException() {
+		super("좌석 중복 선택");
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/exception/exceptions/InvalidPerformanceException.java
+++ b/src/main/java/tback/kicketingback/performance/exception/exceptions/InvalidPerformanceException.java
@@ -1,0 +1,8 @@
+package tback.kicketingback.performance.exception.exceptions;
+
+public class InvalidPerformanceException extends RuntimeException {
+
+	public InvalidPerformanceException() {
+		super("존재하지 않는 공연");
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/exception/exceptions/InvalidSeatIdException.java
+++ b/src/main/java/tback/kicketingback/performance/exception/exceptions/InvalidSeatIdException.java
@@ -1,0 +1,8 @@
+package tback.kicketingback.performance.exception.exceptions;
+
+public class InvalidSeatIdException extends RuntimeException {
+
+	public InvalidSeatIdException() {
+		super("유효하지 않은 좌석");
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/exception/exceptions/NoAvailableSeatsException.java
+++ b/src/main/java/tback/kicketingback/performance/exception/exceptions/NoAvailableSeatsException.java
@@ -1,0 +1,8 @@
+package tback.kicketingback.performance.exception.exceptions;
+
+public class NoAvailableSeatsException extends RuntimeException {
+
+	public NoAvailableSeatsException() {
+		super("예매 가능한 좌석이 없음");
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/PerformanceRepositoryCustom.java
@@ -140,7 +140,7 @@ public class PerformanceRepositoryCustom {
 			.fetch();
 	}
 
-	public boolean findPerformance(UUID performanceUUID, Long onStageId) {
+	public boolean isExistPerformance(UUID performanceUUID, Long onStageId) {
 		Long count = queryFactory.select(onStage.id.count())
 			.from(onStage)
 			.where(onStage.id.eq(onStageId).and(onStage.performance.id.eq(performanceUUID)))

--- a/src/main/java/tback/kicketingback/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/PerformanceRepositoryCustom.java
@@ -139,4 +139,12 @@ public class PerformanceRepositoryCustom {
 			.where(starsIn.performance.id.eq(performanceUUID))
 			.fetch();
 	}
+
+	public boolean findPerformance(UUID performanceUUID, Long onStageId) {
+		Long count = queryFactory.select(onStage.id.count())
+			.from(onStage)
+			.where(onStage.id.eq(onStageId).and(onStage.performance.id.eq(performanceUUID)))
+			.fetchOne();
+		return count > 0;
+	}
 }

--- a/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
@@ -1,0 +1,44 @@
+package tback.kicketingback.performance.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import tback.kicketingback.performance.domain.QReservation;
+import tback.kicketingback.performance.domain.QSeat;
+import tback.kicketingback.performance.dto.SimpleSeatDTO;
+import tback.kicketingback.user.domain.QUser;
+
+@Repository
+public class ReservationRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+	private final QReservation reservation;
+	private final QSeat seat;
+	private final QUser user;
+
+	public ReservationRepositoryCustom(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+		this.reservation = QReservation.reservation;
+		this.seat = QSeat.seat;
+		this.user = QUser.user;
+	}
+
+	public List<SimpleSeatDTO> findOnStageSeats(Long onStageId) {
+		return queryFactory.select(Projections.constructor(SimpleSeatDTO.class,
+				seat.id,
+				seat.grade,
+				seat.seatRow,
+				seat.seatCol))
+			.from(reservation)
+			.join(seat).on(reservation.seat.id.eq(seat.id))
+			.where(reservation.onStage.id.eq(onStageId)
+				.and(reservation.user.id.isNull()
+					.or(seat.lockExpiredTime.before(LocalDateTime.now()).and(reservation.orderNumber.isNull()))))
+			.fetch();
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
@@ -2,6 +2,7 @@ package tback.kicketingback.performance.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -29,8 +30,8 @@ public class ReservationRepositoryCustom {
 		this.user = QUser.user;
 	}
 
-	public List<SimpleSeatDTO> findOnStageSeats(Long onStageId) {
-		return queryFactory.select(Projections.constructor(SimpleSeatDTO.class,
+	public Optional<List<SimpleSeatDTO>> findOnStageSeats(Long onStageId) {
+		List<SimpleSeatDTO> seatDTOS = queryFactory.select(Projections.constructor(SimpleSeatDTO.class,
 				seat.id,
 				seat.grade,
 				seat.seatRow,
@@ -41,11 +42,13 @@ public class ReservationRepositoryCustom {
 				.and(reservation.user.id.isNull()
 					.or(seat.lockExpiredTime.before(LocalDateTime.now()).and(reservation.orderNumber.isNull()))))
 			.fetch();
+		return Optional.ofNullable(seatDTOS.isEmpty() ? null : seatDTOS);
 	}
 
 	public List<SeatReservationDTO> findSeats(List<Long> seatsIds) {
-		return queryFactory.select(Projections.constructor(SeatReservationDTO.class,
-				seat, reservation))
+		return queryFactory.select(
+				Projections.constructor(SeatReservationDTO.class,
+					seat, reservation))
 			.from(reservation)
 			.join(seat).on(reservation.seat.id.eq(seat.id)
 				.and(seat.id.in(seatsIds)))

--- a/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
@@ -11,6 +11,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import tback.kicketingback.performance.domain.QReservation;
 import tback.kicketingback.performance.domain.QSeat;
+import tback.kicketingback.performance.dto.SeatReservationDTO;
 import tback.kicketingback.performance.dto.SimpleSeatDTO;
 import tback.kicketingback.user.domain.QUser;
 
@@ -39,6 +40,15 @@ public class ReservationRepositoryCustom {
 			.where(reservation.onStage.id.eq(onStageId)
 				.and(reservation.user.id.isNull()
 					.or(seat.lockExpiredTime.before(LocalDateTime.now()).and(reservation.orderNumber.isNull()))))
+			.fetch();
+	}
+
+	public List<SeatReservationDTO> findSeats(List<Long> seatsIds) {
+		return queryFactory.select(Projections.constructor(SeatReservationDTO.class,
+				seat, reservation))
+			.from(reservation)
+			.join(seat).on(reservation.seat.id.eq(seat.id)
+				.and(seat.id.in(seatsIds)))
 			.fetch();
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
@@ -39,19 +39,22 @@ public class ReservationRepositoryCustom {
 			.from(reservation)
 			.join(seat).on(reservation.seat.id.eq(seat.id))
 			.where(reservation.onStage.id.eq(onStageId)
-				.and(reservation.user.id.isNull()
-					.or(seat.lockExpiredTime.before(LocalDateTime.now()).and(reservation.orderNumber.isNull()))))
+				.and(reservation.orderNumber.isNull()
+					.and(reservation.user.id.isNull()
+						.or(reservation.lockExpiredTime.isNotNull()
+							.and(reservation.lockExpiredTime.before(LocalDateTime.now()))))))
 			.fetch();
 		return Optional.ofNullable(seatDTOS.isEmpty() ? null : seatDTOS);
 	}
 
-	public List<SeatReservationDTO> findSeats(List<Long> seatsIds) {
+	public List<SeatReservationDTO> findSeats(Long onStageId, List<Long> seatsIds) {
 		return queryFactory.select(
 				Projections.constructor(SeatReservationDTO.class,
 					seat, reservation))
 			.from(reservation)
 			.join(seat).on(reservation.seat.id.eq(seat.id)
 				.and(seat.id.in(seatsIds)))
+			.where(reservation.onStage.id.eq(onStageId))
 			.fetch();
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -35,7 +35,7 @@ public class ReservationService {
 	private final PerformanceRepositoryCustom performanceRepositoryCustom;
 
 	public GetSeatInfoResponse getSeatInfo(UUID performanceUUID, Long onStageId) {
-		if (performanceRepositoryCustom.findPerformance(performanceUUID, onStageId)) {
+		if (!performanceRepositoryCustom.isExistPerformance(performanceUUID, onStageId)) {
 			throw new InvalidPerformanceException();
 		}
 		List<SimpleSeatDTO> onStageSeats = reservationRepositoryCustom.findOnStageSeats(onStageId)

--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -16,6 +16,8 @@ import tback.kicketingback.performance.dto.SeatGradeDTO;
 import tback.kicketingback.performance.dto.SeatReservationDTO;
 import tback.kicketingback.performance.dto.SimpleSeatDTO;
 import tback.kicketingback.performance.exception.exceptions.AlreadySelectedSeatException;
+import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceException;
+import tback.kicketingback.performance.repository.PerformanceRepositoryCustom;
 import tback.kicketingback.performance.repository.ReservationRepositoryCustom;
 import tback.kicketingback.performance.repository.SeatGradeRepository;
 import tback.kicketingback.user.domain.User;
@@ -28,8 +30,12 @@ public class ReservationService {
 	private int lockTime;
 	private final SeatGradeRepository seatGradeRepository;
 	private final ReservationRepositoryCustom reservationRepositoryCustom;
+	private final PerformanceRepositoryCustom performanceRepositoryCustom;
 
 	public GetSeatInfoResponse getSeatInfo(UUID performanceUUID, Long onStageId) {
+		if (performanceRepositoryCustom.findPerformance(performanceUUID, onStageId)) {
+			throw new InvalidPerformanceException();
+		}
 		List<SimpleSeatDTO> onStageSeats = reservationRepositoryCustom.findOnStageSeats(onStageId);
 
 		List<SeatGradeDTO> seatGradeDTOS = seatGradeRepository.findSeatGradesByPerformanceId(performanceUUID).stream()

--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -1,0 +1,38 @@
+package tback.kicketingback.performance.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import tback.kicketingback.performance.dto.GetSeatInfoResponse;
+import tback.kicketingback.performance.dto.SeatGradeDTO;
+import tback.kicketingback.performance.dto.SimpleSeatDTO;
+import tback.kicketingback.performance.repository.ReservationRepositoryCustom;
+import tback.kicketingback.performance.repository.SeatGradeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+	@Value("${reservation-policy.lock-time}")
+	private int lockTime;
+	private final SeatGradeRepository seatGradeRepository;
+	private final ReservationRepositoryCustom reservationRepositoryCustom;
+
+	public GetSeatInfoResponse getSeatInfo(UUID performanceUUID, Long onStageId) {
+		List<SimpleSeatDTO> onStageSeats = reservationRepositoryCustom.findOnStageSeats(onStageId);
+
+		List<SeatGradeDTO> seatGradeDTOS = seatGradeRepository.findSeatGradesByPerformanceId(performanceUUID).stream()
+			.map(seatGrade ->
+				new SeatGradeDTO(seatGrade.getId(),
+					seatGrade.getPerformance().getId(),
+					seatGrade.getGrade(),
+					seatGrade.getPrice()))
+			.toList();
+
+		return new GetSeatInfoResponse(onStageSeats, seatGradeDTOS);
+	}
+}

--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -1,17 +1,24 @@
 package tback.kicketingback.performance.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import tback.kicketingback.performance.domain.Seat;
 import tback.kicketingback.performance.dto.GetSeatInfoResponse;
 import tback.kicketingback.performance.dto.SeatGradeDTO;
+import tback.kicketingback.performance.dto.SeatReservationDTO;
 import tback.kicketingback.performance.dto.SimpleSeatDTO;
+import tback.kicketingback.performance.exception.exceptions.AlreadySelectedSeatException;
 import tback.kicketingback.performance.repository.ReservationRepositoryCustom;
 import tback.kicketingback.performance.repository.SeatGradeRepository;
+import tback.kicketingback.user.domain.User;
 
 @Service
 @RequiredArgsConstructor
@@ -34,5 +41,28 @@ public class ReservationService {
 			.toList();
 
 		return new GetSeatInfoResponse(onStageSeats, seatGradeDTOS);
+	}
+
+	@Transactional(isolation = Isolation.SERIALIZABLE)
+	public void lockSeats(List<Long> seatIds, User user) {
+		List<SeatReservationDTO> seatReservationDTOS = reservationRepositoryCustom.findSeats(seatIds);
+
+		checkSelected(seatReservationDTOS);
+
+		seatReservationDTOS.forEach(seatReservationDTO -> {
+			seatReservationDTO.reservation().setUser(user);
+			seatReservationDTO.seat().setLockExpiredTime(LocalDateTime.now().plusMinutes(lockTime));
+		});
+	}
+
+	private void checkSelected(List<SeatReservationDTO> seatReservationDTOS) {
+		List<Seat> reservedSeats = seatReservationDTOS.stream()
+			.filter(seatReservationDTO -> seatReservationDTO.reservation().getOrderNumber() != null ||
+				(seatReservationDTO.seat().getLockExpiredTime().isAfter(LocalDateTime.now())))
+			.map(SeatReservationDTO::seat)
+			.toList();
+		if (!reservedSeats.isEmpty()) {
+			throw AlreadySelectedSeatException.of(reservedSeats);
+		}
 	}
 }

--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -17,6 +17,8 @@ import tback.kicketingback.performance.dto.SeatReservationDTO;
 import tback.kicketingback.performance.dto.SimpleSeatDTO;
 import tback.kicketingback.performance.exception.exceptions.AlreadySelectedSeatException;
 import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceException;
+import tback.kicketingback.performance.exception.exceptions.InvalidSeatIdException;
+import tback.kicketingback.performance.exception.exceptions.NoAvailableSeatsException;
 import tback.kicketingback.performance.repository.PerformanceRepositoryCustom;
 import tback.kicketingback.performance.repository.ReservationRepositoryCustom;
 import tback.kicketingback.performance.repository.SeatGradeRepository;
@@ -36,7 +38,8 @@ public class ReservationService {
 		if (performanceRepositoryCustom.findPerformance(performanceUUID, onStageId)) {
 			throw new InvalidPerformanceException();
 		}
-		List<SimpleSeatDTO> onStageSeats = reservationRepositoryCustom.findOnStageSeats(onStageId);
+		List<SimpleSeatDTO> onStageSeats = reservationRepositoryCustom.findOnStageSeats(onStageId)
+			.orElseThrow(NoAvailableSeatsException::new);
 
 		List<SeatGradeDTO> seatGradeDTOS = seatGradeRepository.findSeatGradesByPerformanceId(performanceUUID).stream()
 			.map(seatGrade ->
@@ -53,6 +56,9 @@ public class ReservationService {
 	public void lockSeats(List<Long> seatIds, User user) {
 		List<SeatReservationDTO> seatReservationDTOS = reservationRepositoryCustom.findSeats(seatIds);
 
+		if (seatIds.size() != seatReservationDTOS.size()) {
+			throw new InvalidSeatIdException();
+		}
 		checkSelected(seatReservationDTOS);
 
 		seatReservationDTOS.forEach(seatReservationDTO -> {

--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -55,7 +55,6 @@ public class ReservationService {
 	@Transactional(isolation = Isolation.SERIALIZABLE)
 	public void lockSeats(Long onStageId, List<Long> seatIds, User user) {
 		List<SeatReservationDTO> seatReservationDTOS = reservationRepositoryCustom.findSeats(onStageId, seatIds);
-		System.out.println("seatReservationDTOS = " + seatReservationDTOS);
 
 		if (seatIds.size() != seatReservationDTOS.size()) {
 			throw new InvalidSeatIdException();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
       - classpath:config/application-oauth.properties
       - classpath:config/application-redis.properties
       - classpath:config/application-smtp.properties
+      - classpath:config/application-policy.properties
   datasource:
     url: ${spring.datasource.url}
     username: ${spring.datasource.username}
@@ -86,3 +87,6 @@ oauth:
       token:
         redirect:
           uri: ${oauth.google.token.redirect.uri}
+
+reservation-policy:
+  lock-time: ${reservation-policy.lock-time}

--- a/src/test/java/tback/kicketingback/performance/service/ReservationServiceTest.java
+++ b/src/test/java/tback/kicketingback/performance/service/ReservationServiceTest.java
@@ -1,0 +1,106 @@
+package tback.kicketingback.performance.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import tback.kicketingback.performance.dto.GetSeatInfoResponse;
+import tback.kicketingback.performance.exception.exceptions.AlreadySelectedSeatException;
+import tback.kicketingback.performance.exception.exceptions.InvalidPerformanceException;
+import tback.kicketingback.performance.exception.exceptions.InvalidSeatIdException;
+import tback.kicketingback.performance.exception.exceptions.NoAvailableSeatsException;
+import tback.kicketingback.user.domain.User;
+import tback.kicketingback.user.repository.UserRepository;
+
+@SpringBootTest
+class ReservationServiceTest {
+
+	@Autowired
+	private ReservationService reservationService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("[실패] 공연 uuid와 OnStage Id가 연관이 없을 때")
+	void getSeatInfoByMismatchPerformanceUUIDAndOnStageId() {
+		UUID performanceUUID = UUID.fromString("069939e9-dfed-46b5-832e-996cd737584a");
+		Long onStageId = 9L;
+
+		assertThatThrownBy(() -> {
+			reservationService.getSeatInfo(performanceUUID, onStageId);
+		}).isInstanceOf(InvalidPerformanceException.class);
+	}
+
+	@Test
+	@DisplayName("[실패] 예약 가능한 좌석이 없음")
+	void getSeatInfoByNoSeat() {
+		UUID performanceUUID = UUID.fromString("28f4caa7-84f8-4ff1-a4b7-ce0fc6e171aa");
+		Long onStageId = 20L;
+
+		assertThatThrownBy(() -> {
+			reservationService.getSeatInfo(performanceUUID, onStageId);
+		}).isInstanceOf(NoAvailableSeatsException.class);
+	}
+
+	@Test
+	@DisplayName("[성공] 예약 가능한 좌석 정보 제공")
+	void getSeatInfo() {
+		UUID performanceUUID = UUID.fromString("0d6951b4-f86d-4707-a42c-53509774ffbc");
+		Long onStageId = 9L;
+
+		assertThatCode(() -> {
+			GetSeatInfoResponse seatInfo = reservationService.getSeatInfo(performanceUUID, onStageId);
+			System.out.println("seatInfo = " + seatInfo);
+			assertThat(seatInfo.simpleSeatDTOS().size()).isGreaterThanOrEqualTo(1);
+			assertThat(seatInfo.seatGradeDTOS().size()).isGreaterThanOrEqualTo(1);
+		}).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("[실패] 유효하지 않은 좌석")
+	void lockSeatsByInvalidSeatId() {
+		Long onStageId = 1000L;
+		List<Long> invalidSeatIds = List.of(10000L, 20000L, 30000L);
+		User testUser = userRepository.findByEmail("test@test.com").get();
+
+		assertThatThrownBy(() -> {
+			reservationService.lockSeats(onStageId, invalidSeatIds, testUser);
+		}).isInstanceOf(InvalidSeatIdException.class);
+	}
+
+	@Test
+	@DisplayName("[실패] 이미 예약이 완료됐거나 점유 중인 좌석이 포함")
+	void lockSeatsByAlreadySelectedSeat() {
+		Long onStageId = 20L;
+		List<Long> selectedSeatIds = List.of(298L, 299L, 300L);
+		User testUser = userRepository.findByEmail("test@test.com").get();
+
+		assertThatThrownBy(() -> {
+			reservationService.lockSeats(onStageId, selectedSeatIds, testUser);
+		}).isInstanceOf(AlreadySelectedSeatException.class);
+	}
+
+	@Test
+	@DisplayName("[성공] 좌석 점유가 완료됨")
+	void lockSeats() {
+		Long onStageId = 9L;
+		List<Long> selectedSeatIds = List.of(111L, 112L, 113L);
+		User testUser = userRepository.findByEmail("test@test.com").get();
+
+		assertThatCode(() -> {
+			reservationService.lockSeats(onStageId, selectedSeatIds, testUser);
+		}).doesNotThrowAnyException();
+
+		UUID performanceUUID = UUID.fromString("0d6951b4-f86d-4707-a42c-53509774ffbc");
+		assertThatThrownBy(() -> {
+			reservationService.getSeatInfo(performanceUUID, onStageId);
+		}).isInstanceOf(NoAvailableSeatsException.class);
+	}
+}


### PR DESCRIPTION
## 📄 Summary
> #66
- 예매가능 좌석, 공연 좌석 등급별 정보 제공 기능
- 공연 UUID, 회차별 공연 id를 제공받아 예매 가능한 좌석을 조회합니다.
- 예매하려는 공연의 회차 id와 좌석id들을 제공받아 좌석을 점유합니다.

## 🙋🏻 More
> 자세한 api 스펙은 포스트맨을 참고해주세요!!
핵심 비지니스 로직이니 예외 응답이나 자리 점유(락) 로직을 꼭 확인해주세요!!
