### PR TITLE
fix : 한 유저가 같은 자리를 계속 점유하는 버그 수정

### DIFF
--- a/src/main/java/tback/kicketingback/performance/service/ReservationService.java
+++ b/src/main/java/tback/kicketingback/performance/service/ReservationService.java
@@ -94,7 +94,6 @@ public class ReservationService {
 		User user
 	) {
 		List<SeatReservationDTO> seatReservationDTOS = getSeatReservationDTOS(onStageId, seatIds);
-		checkSelected(seatReservationDTOS, user);
 		checkMySeats(user, seatReservationDTOS);
 
 		validatePayment(orderNumber);
@@ -147,7 +146,6 @@ public class ReservationService {
 		List<Seat> reservedSeats = seatReservationDTOS.stream()
 			.filter(seatReservationDTO -> seatReservationDTO.reservation().getOrderNumber() != null ||
 				(seatReservationDTO.reservation().getUser().getId() != null &&
-					!seatReservationDTO.reservation().getUser().getId().equals(user.getId()) &&
 					(seatReservationDTO.reservation().getLockExpiredTime() != null &&
 						seatReservationDTO.reservation().getLockExpiredTime().isAfter(LocalDateTime.now()))))
 			.map(SeatReservationDTO::seat)
@@ -160,7 +158,8 @@ public class ReservationService {
 	private void checkMySeats(User user, List<SeatReservationDTO> seatReservationDTOS) {
 		List<Seat> mySeats = seatReservationDTOS.stream()
 			.filter(seatReservationDTO ->
-				seatReservationDTO.reservation().getUser().getId() != null &&
+				seatReservationDTO.reservation().getOrderNumber() == null &&
+					seatReservationDTO.reservation().getUser().getId() != null &&
 					seatReservationDTO.reservation().getUser().getId().equals(user.getId()) &&
 					seatReservationDTO.reservation().getLockExpiredTime() != null &&
 					seatReservationDTO.reservation().getLockExpiredTime().isAfter(LocalDateTime.now()))


### PR DESCRIPTION
- 좌석 점유 시간이 끝난 후에 다시 점유할 수 있음

## 📄 Summary
> #90 
특정 유저가 같은 좌석을 락 시간이 끝나기 전에 계속 점유 요청해 락 시간이 무한히 길어지는 버그 수정
좌석 점유는 락 시간이 끝나고 다시 가능함

## 🙋🏻 More
> 생각하지 못했던 버그인데 @pwrwpw 굿입니다!
