### PR TITLE
refact : 좌석 목록 제공 리펙토링

### DIFF
--- a/src/main/java/tback/kicketingback/performance/dto/GetSeatInfoResponse.java
+++ b/src/main/java/tback/kicketingback/performance/dto/GetSeatInfoResponse.java
@@ -3,7 +3,8 @@ package tback.kicketingback.performance.dto;
 import java.util.List;
 
 public record GetSeatInfoResponse(
-	List<SimpleSeatDTO> simpleSeatDTOS,
+	List<SimpleSeatDTO> bookableSeats,
+	List<SimpleSeatDTO> unbookableSeats,
 	List<SeatGradeDTO> seatGradeDTOS
 ) {
 }

--- a/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/tback/kicketingback/performance/repository/ReservationRepositoryCustom.java
@@ -27,7 +27,6 @@ import tback.kicketingback.performance.dto.SeatGradeDTO;
 import tback.kicketingback.performance.dto.SeatReservationDTO;
 import tback.kicketingback.performance.dto.SimplePerformanceDTO;
 import tback.kicketingback.performance.dto.SimpleReservationDTO;
-import tback.kicketingback.performance.dto.SimpleSeatDTO;
 import tback.kicketingback.user.domain.QUser;
 
 @Repository
@@ -72,21 +71,13 @@ public class ReservationRepositoryCustom {
 		return Optional.ofNullable(gradeCountList.isEmpty() ? null : gradeCountList);
 	}
 
-	public Optional<List<SimpleSeatDTO>> findOnStageSeats(Long onStageId) {
-		List<SimpleSeatDTO> seatDTOS = queryFactory.select(Projections.constructor(SimpleSeatDTO.class,
-				seat.id,
-				seat.grade,
-				seat.seatRow,
-				seat.seatCol))
+	public List<SeatReservationDTO> findOnStageSeats(Long onStageId) {
+		return queryFactory.select(Projections.constructor(SeatReservationDTO.class,
+				seat, reservation))
 			.from(reservation)
 			.join(seat).on(reservation.seat.id.eq(seat.id))
-			.where(reservation.onStage.id.eq(onStageId)
-				.and(reservation.orderNumber.isNull()
-					.and(reservation.user.id.isNull()
-						.or(reservation.lockExpiredTime.isNotNull()
-							.and(reservation.lockExpiredTime.before(LocalDateTime.now()))))))
+			.where(reservation.onStage.id.eq(onStageId))
 			.fetch();
-		return Optional.ofNullable(seatDTOS.isEmpty() ? null : seatDTOS);
 	}
 
 	public List<SeatReservationDTO> findSeats(Long onStageId, List<Long> seatsIds) {


### PR DESCRIPTION
- 예매 가능한 좌석 목록과 예매 불가능한 좌석 목록을 같이 제공함

## 📄 Summary
> #110 
예매 가능한 좌석 목록을 제공할 때 예매 불가능한 목록도 같이 제공하도록 리펙토링 했습니다

## 🙋🏻 More
> 프론트에 api 붙이다보니 역시 기능을 수정할 일이 생기네요
